### PR TITLE
Fix TypeError on save as when no task

### DIFF
--- a/python/tk_multi_workfiles/save_as.py
+++ b/python/tk_multi_workfiles/save_as.py
@@ -84,9 +84,11 @@ class SaveAs(object):
             else:
                 # get the default name from settings:
                 default_name = self._app.get_setting("saveas_default_name")
-                if not default_name:
-                    # if no default name set, use the taank_name of the task
-                    task = self._app.shotgun.find_one("Task",[["id","is",self._app.context.task["id"]]],['sg_tank_name'])
+                if not default_name and self._app.context.task:
+                    # if no default name set, use the tank_name of the task
+                    task = self._app.shotgun.find_one("Task",
+                                                      [["id", "is", self._app.context.task["id"]]],
+                                                      ['sg_tank_name'])
                     default_name = task.get('sg_tank_name')
 
                 if not default_name and not name_is_optional:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.3_rdo2/app.py", line 112, in show_save_as_dlg
    return tk_multi_workfiles.SaveAs.show_save_as_dlg(self)
  File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.3_rdo2/python/tk_multi_workfiles/save_as.py", line 39, in show_save_as_dlg
    handler._show_save_as_dlg()
  File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.3_rdo2/python/tk_multi_workfiles/save_as.py", line 89, in _show_save_as_dlg
    task = self._app.shotgun.find_one("Task",[["id","is",self._app.context.task["id"]]],['sg_tank_name'])
TypeError: 'NoneType' object has no attribute '__getitem__'
```
