### PR TITLE
apply new context when File Manager is closed

### DIFF
--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -99,6 +99,8 @@ class WorkFiles(object):
         self._workfiles_ui.show_in_fs.connect(self._on_show_in_file_system)
         self._workfiles_ui.show_in_shotgun.connect(self._on_show_in_shotgun)
         
+        self._workfiles_ui.apply_context.connect(self._on_apply_context)
+
     def find_files(self, filter):
         """
         Find files using the current context, work and publish templates
@@ -709,6 +711,20 @@ class WorkFiles(object):
         # close work files UI:
         self._workfiles_ui.close()
         
+    def _on_apply_context(self):
+        """
+        Ask the user if the new context should be applied.
+        Called from WorkFileForm close event
+        """
+        if not self._context == self._app.context:
+            res = QtGui.QMessageBox.question(self._workfiles_ui,
+                                             "Change Work Area ?",
+                                             "You've selected a new context. Do you wish to change your Work Area ?",
+                                             QtGui.QMessageBox.Ok|QtGui.QMessageBox.Cancel)
+            if res == QtGui.QMessageBox.Ok:
+                # restart the engine with the new context
+                self._restart_engine(self._context)
+
     def get_current_work_area(self):
         """
         Get the current work area/context

--- a/python/tk_multi_workfiles/work_files_form.py
+++ b/python/tk_multi_workfiles/work_files_form.py
@@ -38,6 +38,8 @@ class WorkFilesForm(QtGui.QWidget):
     show_in_fs = QtCore.Signal()
     show_in_shotgun = QtCore.Signal(object)#FileItem
     
+    apply_context = QtCore.Signal()
+
     def __init__(self, app, handler, parent = None):
         """
         Construction
@@ -127,6 +129,7 @@ class WorkFilesForm(QtGui.QWidget):
         the widget is closed
         """
         self._ui.file_list.destroy()
+        self.apply_context.emit()
         return QtGui.QWidget.closeEvent(self, e)
         
     def _on_open_file(self):


### PR DESCRIPTION
It's very confusing to select a new context in the File Manager and not having it applied when deciding not to open or create a file.
