### PR TITLE
[FRI] save_as: ensure default name is not None

### DIFF
--- a/python/tk_multi_workfiles/save_as.py
+++ b/python/tk_multi_workfiles/save_as.py
@@ -91,7 +91,7 @@ class SaveAs(object):
                     task = self._app.shotgun.find_one("Task",
                                                       [["id", "is", self._app.context.task["id"]]],
                                                       ['sg_tank_name'])
-                    default_name = task.get('sg_tank_name')
+                    default_name = task.get('sg_tank_name') or ''
 
                 if not default_name and not name_is_optional:
                     # name isn't optional so we should use something:


### PR DESCRIPTION
Stumbled on this error while testing the app in Katana...

Need https://bitbucket.org/rodeofx/tk_config_rdo_default/pull-requests/280/fri-env-includes-tk-multi-loader2-update/diff

```
[ERROR python.root]: A TypeError occurred in "save_as_form.py": QLineEdit.setText(QString): argument 1 has unexpected type 'NoneType'
    Traceback (most recent call last):
      File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.17_rdo1/app.py", line 112, in show_save_as_dlg
        return tk_multi_workfiles.SaveAs.show_save_as_dlg(self)
      File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.17_rdo1/python/tk_multi_workfiles/save_as.py", line 38, in show_save_as_dlg
        handler._show_save_as_dlg()
      File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.17_rdo1/python/tk_multi_workfiles/save_as.py", line 163, in _show_save_as_dlg
        is_publish, name_is_used, name, version_is_used)
      File "/rdo/rodeo/repositories/tank/studio/install/core/python/tank/platform/engine.py", line 974, in show_modal
        dialog, widget = self._create_dialog_with_widget(title, bundle, widget_class, *args, **kwargs)
      File "/rdo/rodeo/repositories/tank/studio/install/core/python/tank/platform/engine.py", line 847, in _create_dialog_with_widget
        widget = self._create_widget(widget_class, *args, **kwargs)
      File "/rdo/rodeo/repositories/tank/studio/install/core/python/tank/platform/engine.py", line 825, in _create_widget
        widget = derived_widget_class(*args, **kwargs)
      File "/rdo/rodeo/repositories/tank/studio/install/apps/git/tk-multi-workfiles.git/v0.6.17_rdo1/python/tk_multi_workfiles/save_as_form.py", line 63, in __init__
        self._ui.name_edit.setText(name)
    TypeError: QLineEdit.setText(QString): argument 1 has unexpected type 'NoneType'
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rodeofx/tk-multi-workfiles/10)

<!-- Reviewable:end -->
