### PR TITLE
DCC(nuke) context switch: verify that new shot/entity is Rez-compatible with current (RND-342)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 *.py[cod]
 
 # C extensions
@@ -6,8 +7,8 @@
 # Packages
 *.egg
 *.egg-info
-dist
-build
+/dist
+/build
 eggs
 parts
 bin
@@ -22,14 +23,15 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
-.coverage
-.tox
-nosetests.xml
+/.coverage
+/.tox
+/nosetests.xml
 
 # Translations
 *.mo
 
 # Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
+/.mr.developer.cfg
+/.project
+/.pydevproject
+/.idea/

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -756,7 +756,7 @@ class WorkFiles(object):
 
             # widget.context contains the selected context (shot or entity)
             if os.getenv('REZ_USED_REQUEST'):
-                # we are under Rez, some entity may not be compatible with current one..
+                # we are under Rez, some entity may not be *-* Rez *-* compatible with current one..
                 # delayed import on purpose, not available outside of rez:
                 new_ctx = widget.context
                 from rdo_rez_launcher.tools import start_app_if_new_entity_incompatible
@@ -767,6 +767,8 @@ class WorkFiles(object):
                     tank_config_name=new_ctx.tank.configuration_name
                 ):
                     # this means the new entity isn't compatible with current one and we stop here,
+                    # by compatible we mean: the new entity has different Rez packages configured than
+                    # the current entity. In that case (any diff): we don't play with fire and ..
                     # user may have accepted to start new DCC instance and if it's yes then at this point
                     # the new instance is just starting up ..
                     return

--- a/python/tk_multi_workfiles/work_files.py
+++ b/python/tk_multi_workfiles/work_files.py
@@ -754,6 +754,23 @@ class WorkFiles(object):
 
             do_new = widget.do_new_scene
 
+            # widget.context contains the selected context (shot or entity)
+            if os.getenv('REZ_USED_REQUEST'):
+                # we are under Rez, some entity may not be compatible with current one..
+                # delayed import on purpose, not available outside of rez:
+                new_ctx = widget.context
+                from rdo_rez_launcher.tools import start_app_if_new_entity_incompatible
+                if start_app_if_new_entity_incompatible(
+                    lambda title, message: QtGui.QMessageBox.Yes == QtGui.QMessageBox.question(
+                        None, title, message, QtGui.QMessageBox.Yes | QtGui.QMessageBox.No),
+                    new_ctx.tank.shotgun, new_ctx.entity['name'],
+                    tank_config_name=new_ctx.tank.configuration_name
+                ):
+                    # this means the new entity isn't compatible with current one and we stop here,
+                    # user may have accepted to start new DCC instance and if it's yes then at this point
+                    # the new instance is just starting up ..
+                    return
+
             # update the current work area in the app:
             self._update_current_work_area(widget.context)
             


### PR DESCRIPTION
# Purpose #

Allow change of context when under Rez and detects if the newly desired context (shot or entity) is compatible with the current/previous one.
If not launch a new DCC via rdo_rez_launcher regularly.

# Risk # 

Should be low : 
+ when not under rez this is a no-op basically.
+ when under rez: well the check is done and if need to be a new DCC process instance is started (the current one is kept open).


# Requires #

https://bitbucket.org/rodeofx/rdo_rez_launcher/pull-requests/24/rnd-342-nuke-context-switch-verify-that/diff