### PR TITLE
[dev] Disable thumbnails to workaround crash

### DIFF
--- a/python/tk_multi_workfiles/entity_browser.py
+++ b/python/tk_multi_workfiles/entity_browser.py
@@ -136,8 +136,9 @@ class EntityBrowserWidget(browser_widget.BrowserWidget):
                 
                 i.set_details(details)
                 i.sg_data = d
-                if d.get("image"):
-                    i.set_thumbnail(d.get("image"))
+                # RDO: Removed to prevent crash
+                # if d.get("image"):
+                #     i.set_thumbnail(d.get("image"))
                     
                 if (d and current_entity 
                     and d["id"] == current_entity.get("id") 

--- a/python/tk_multi_workfiles/task_browser.py
+++ b/python/tk_multi_workfiles/task_browser.py
@@ -200,18 +200,19 @@ class TaskBrowserWidget(browser_widget.BrowserWidget):
                         i.grab_action.triggered.connect(self.grab_task)                       
                         i.addAction(i.grab_action)
                         i.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)                
-                
-                # finally look up the thumbnail for the first user assigned to the task
-                task_assignees = d.get("task_assignees", [])
-                if len(task_assignees) > 0:
-                    user_id = task_assignees[0]["id"]
-                    # is this user id in our users dict? In that case we have their thumb!
-                    for u in result["users"]:
-                        if u["id"] == user_id:
-                            # if they have a thumb, assign!
-                            if u.get("image"):
-                                i.set_thumbnail(u.get("image"))
-                            break            
+
+                # RDO: Removed to prevent crash
+                # # finally look up the thumbnail for the first user assigned to the task
+                # task_assignees = d.get("task_assignees", [])
+                # if len(task_assignees) > 0:
+                #     user_id = task_assignees[0]["id"]
+                #     # is this user id in our users dict? In that case we have their thumb!
+                #     for u in result["users"]:
+                #         if u["id"] == user_id:
+                #             # if they have a thumb, assign!
+                #             if u.get("image"):
+                #                 i.set_thumbnail(u.get("image"))
+                #             break
                 
                 if d and current_task and d["id"] == current_task.get("id"):
                     item_to_select = i

--- a/python/tk_multi_workfiles/work_files_form.py
+++ b/python/tk_multi_workfiles/work_files_form.py
@@ -322,15 +322,16 @@ class WorkFilesForm(QtGui.QWidget):
             project_name = ctx.project.get("name") or sg_details.get("code")
             self._ui.project_label.setText("Project: %s" % (project_name or "-"))
             self._ui.project_frame.setToolTip("%s" % (project_name or ""))
-            
-            # thumbnail:
-            project_thumbnail = QtGui.QPixmap()
-            project_img_url = sg_details.get("image")
-            if project_img_url:
-                thumbnail_path = self._download_thumbnail(project_img_url)
-                if thumbnail_path:
-                    project_thumbnail = QtGui.QPixmap(thumbnail_path)
-            self._set_thumbnail(self._ui.project_thumbnail, project_thumbnail)
+
+            # RDO: Removed to prevent crash
+            # # thumbnail:
+            # project_thumbnail = QtGui.QPixmap()
+            # project_img_url = sg_details.get("image")
+            # if project_img_url:
+            #     thumbnail_path = self._download_thumbnail(project_img_url)
+            #     if thumbnail_path:
+            #         project_thumbnail = QtGui.QPixmap(thumbnail_path)
+            # self._set_thumbnail(self._ui.project_thumbnail, project_thumbnail)
                                 
             # description:
             desc = sg_details.get("sg_description") or "<i>No description was entered for this Project</i>"
@@ -359,15 +360,16 @@ class WorkFilesForm(QtGui.QWidget):
                 entity_name = ctx.entity.get("name") or sg_details.get("code")
                 self._ui.entity_label.setText("%s: %s" % (entity_type_name, entity_name or "-"))
                 self._ui.entity_frame.setToolTip("%s" % (entity_name or ""))
-                
-                # thumbnail:
-                entity_thumbnail = QtGui.QPixmap()
-                entity_img_url = sg_details.get("image")
-                if entity_img_url:
-                    thumbnail_path = self._download_thumbnail(entity_img_url)
-                    if thumbnail_path:
-                        entity_thumbnail = QtGui.QPixmap(thumbnail_path)
-                self._set_thumbnail(self._ui.entity_thumbnail, entity_thumbnail)
+
+                # RDO: Removed to prevent crash
+                # # thumbnail:
+                # entity_thumbnail = QtGui.QPixmap()
+                # entity_img_url = sg_details.get("image")
+                # if entity_img_url:
+                #     thumbnail_path = self._download_thumbnail(entity_img_url)
+                #     if thumbnail_path:
+                #         entity_thumbnail = QtGui.QPixmap(thumbnail_path)
+                # self._set_thumbnail(self._ui.entity_thumbnail, entity_thumbnail)
                                     
                 # description including the display of extra fields:
                 extra_info = ", ".join(["%s: %s" % (label, str(sg_details.get(field))) 
@@ -397,27 +399,28 @@ class WorkFilesForm(QtGui.QWidget):
                     task_name = ctx.task.get("name") or sg_details.get("content")
                     self._ui.task_label.setText("Task: %s" % (task_name or "-"))
                     self._ui.task_frame.setToolTip("%s" % (task_name or ""))
-                    
-                    # thumbnail:
-                    task_thumbnail = QtGui.QPixmap()
-                    task_assignees = sg_details.get("task_assignees", [])
-                    if len(task_assignees) > 0:
-                        user_id = task_assignees[0]["id"]
-                        
-                        sg_user_details = {}
-                        try:
-                            sg_user_details = self._app.shotgun.find_one("HumanUser", [["id", "is", user_id]], ["image"])
-                        except Exception, e:
-                            pass
-                        
-                        if sg_user_details:
-                            img_url = sg_user_details.get("image")
-                            if img_url:
-                                thumbnail_path = self._download_thumbnail(img_url)
-                                if thumbnail_path:
-                                    task_thumbnail = QtGui.QPixmap(thumbnail_path)
-                                
-                    self._set_thumbnail(self._ui.task_thumbnail, task_thumbnail)
+
+                    # RDO: Removed to prevent crash
+                    # # thumbnail:
+                    # task_thumbnail = QtGui.QPixmap()
+                    # task_assignees = sg_details.get("task_assignees", [])
+                    # if len(task_assignees) > 0:
+                    #     user_id = task_assignees[0]["id"]
+                    #
+                    #     sg_user_details = {}
+                    #     try:
+                    #         sg_user_details = self._app.shotgun.find_one("HumanUser", [["id", "is", user_id]], ["image"])
+                    #     except Exception, e:
+                    #         pass
+                    #
+                    #     if sg_user_details:
+                    #         img_url = sg_user_details.get("image")
+                    #         if img_url:
+                    #             thumbnail_path = self._download_thumbnail(img_url)
+                    #             if thumbnail_path:
+                    #                 task_thumbnail = QtGui.QPixmap(thumbnail_path)
+                    #
+                    # self._set_thumbnail(self._ui.task_thumbnail, task_thumbnail)
                     
                     # details
                     assignees = []


### PR DESCRIPTION
#### Purpose of the PR

This PR is a hotpatch that disable any thumbnails in the app.
We know this crashed previously when using https, however it started crashing this week and we are not sure why. This patch should be temporary until we move nuke to tk-multi-workfiles2.

#### Overview of the changes

Commented out any code related to thumbnail.

#### Type of feedback wanted

Any kind of feedback.

#### Where should the reviewer start looking at?

Diff should be enough

#### Potential risks of this change

Medium, there will be no thumbnails.

#### Relationship with other PRs

None
